### PR TITLE
Robustness for duplicate ids, pimplification etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Makefile
 moc_*
 *.o
+*.so
+*.so.*

--- a/rpm/grilo-qt5.spec
+++ b/rpm/grilo-qt5.spec
@@ -1,7 +1,7 @@
 Name:       grilo-qt5
 
 Summary:    Framework for discovering and browsing media, Qt bindings
-Version:    0.3.3
+Version:    0.4.0
 Release:    1
 License:    LGPLv2+
 URL:        https://github.com/sailfishos/qtgrilo
@@ -40,7 +40,6 @@ make %{?_smp_mflags}
 
 
 %install
-rm -rf %{buildroot}
 %qmake5_install
 
 %post -p /sbin/ldconfig
@@ -48,12 +47,10 @@ rm -rf %{buildroot}
 %postun -p /sbin/ldconfig
 
 %files
-%defattr(-,root,root,-)
 %license COPYING
 %{_libdir}/lib*.so.*
 
 %files devel
-%defattr(-,root,root,-)
 %{_datarootdir}/qt5/mkspecs/features/%{name}.prf
 %{_includedir}/qt5/GriloQt/GriloBrowse
 %{_includedir}/qt5/GriloQt/GriloDataSource
@@ -76,7 +73,6 @@ rm -rf %{buildroot}
 %{_libdir}/pkgconfig/%{name}.pc
 
 %files qml-plugin
-%defattr(-,root,root,-)
 %{_libdir}/qt5/qml/org/nemomobile/grilo/libgrilo-qt5-qml-plugin.so
 %{_libdir}/qt5/qml/org/nemomobile/grilo/plugins.qmltypes
 %{_libdir}/qt5/qml/org/nemomobile/grilo/qmldir

--- a/src/grilobrowse.h
+++ b/src/grilobrowse.h
@@ -28,6 +28,7 @@
 #include <GriloDataSource>
 
 class GriloMedia;
+class GriloBrowsePrivate;
 
 class GRILO_QT_EXPORT GriloBrowse : public GriloDataSource
 {
@@ -65,16 +66,9 @@ Q_SIGNALS:
 
 private:
     void availableSourcesChanged();
-
     GrlMedia *rootMedia();
 
-    QString m_source;
-
-    GriloMedia *m_media;
-    QString m_baseMedia;
-    QVariantList m_slowKeys;
-    QVariantList m_supportedKeys;
-    bool m_available;
+    GriloBrowsePrivate *d;
 };
 
 #endif /* GRILO_BROWSE_H */

--- a/src/grilodatasource.cpp
+++ b/src/grilodatasource.cpp
@@ -53,6 +53,7 @@ public:
     QList<GriloModel *> m_models;
     QHash<QString, GriloMedia *> m_hash;
     bool m_fetching;
+    bool m_initialFetchDone = false;
 };
 
 GriloDataSourcePrivate::GriloDataSourcePrivate()
@@ -114,7 +115,9 @@ void GriloDataSource::addMedia(GrlMedia *media)
 {
     GriloMedia *wrappedMedia = 0;
 
-    if (d->m_insertIndex < d->m_media.count()) {
+    // on first fetch we should be sure that there's nothing to move yet.
+    // TODO: figure out a way to avoid QList::indexOf() with each row on an update
+    if (!d->m_initialFetchDone && d->m_insertIndex < d->m_media.count()) {
         wrappedMedia = d->m_hash.value(QString::fromUtf8(grl_media_get_id(media)), 0);
     }
 
@@ -403,6 +406,7 @@ void GriloDataSource::grilo_source_result_cb(GrlSource *source, guint op_id,
     }
 
     if (remaining == 0) {
+        that->d->m_initialFetchDone = true;
         that->d->m_opId = 0;
 
         if (that->d->m_updateScheduled) {

--- a/src/grilodatasource.cpp
+++ b/src/grilodatasource.cpp
@@ -61,7 +61,7 @@ const QList<GriloMedia *> *GriloDataSource::media() const
 void GriloDataSource::addModel(GriloModel *model)
 {
     if (m_models.indexOf(model) == -1) {
-        m_models << model;
+        m_models.append(model);
     }
 }
 
@@ -118,8 +118,14 @@ void GriloDataSource::addMedia(GrlMedia *media)
             return;
         }
     }
-
     wrappedMedia = new GriloMedia(media);
+    QString id = wrappedMedia->id();
+
+    if (!id.isEmpty() && m_hash.contains(id)) {
+        qWarning() << "Duplicate id detected on qtgrilo model source, ignored to keep model sane. Id:" << id;
+        delete wrappedMedia;
+        return;
+    }
 
     Q_FOREACH (GriloModel *model, m_models) {
         model->beginInsertRows(QModelIndex(), m_insertIndex, m_insertIndex);
@@ -128,7 +134,6 @@ void GriloDataSource::addMedia(GrlMedia *media)
     m_media.insert(m_insertIndex, wrappedMedia);
     ++m_insertIndex;
 
-    QString id = wrappedMedia->id();
     if (!id.isEmpty()) {
         m_hash.insert(id, wrappedMedia);
     }
@@ -136,7 +141,6 @@ void GriloDataSource::addMedia(GrlMedia *media)
     Q_FOREACH (GriloModel *model, m_models) {
         model->endInsertRows();
     }
-
 }
 
 void GriloDataSource::removeMedia(GrlMedia *media)
@@ -340,7 +344,6 @@ void GriloDataSource::grilo_source_result_cb(GrlSource *source, guint op_id,
                                              GrlMedia *media, guint remaining,
                                              gpointer user_data, const GError *error)
 {
-
     Q_UNUSED(source)
 
     // We get an error if the operation has been canceled:

--- a/src/grilodatasource.cpp
+++ b/src/grilodatasource.cpp
@@ -446,3 +446,18 @@ void GriloDataSource::timerEvent(QTimerEvent *event)
         Q_EMIT contentUpdated();
     }
 }
+
+guint GriloDataSource::getOpId() const
+{
+    return m_opId;
+}
+
+void GriloDataSource::setOpId(guint id)
+{
+    m_opId = id;
+}
+
+GriloRegistry *GriloDataSource::getGriloRegistry() const
+{
+    return m_registry;
+}

--- a/src/grilodatasource.h
+++ b/src/grilodatasource.h
@@ -36,6 +36,8 @@ class GriloMedia;
 class GriloModel;
 class GriloRegistry;
 
+class GriloDataSourcePrivate;
+
 class GRILO_QT_EXPORT GriloDataSource : public QObject
 {
     Q_OBJECT
@@ -182,21 +184,7 @@ protected Q_SLOTS:
                                 GPtrArray *changed_media);
 
 private:
-    guint m_opId;
-    GriloRegistry *m_registry;
-
-    int m_count;
-    int m_skip;
-    int m_insertIndex;
-    QVariantList m_metadataKeys;
-    QVariantList m_typeFilter;
-
-    bool m_updateScheduled;
-    QBasicTimer m_updateTimer;
-    QList<GriloMedia *> m_media;
-    QList<GriloModel *> m_models;
-    QHash<QString, GriloMedia *> m_hash;
-    bool m_fetching;
+    GriloDataSourcePrivate *d;
 };
 
 #endif /* GRILO_DATA_SOURCE_H */

--- a/src/grilodatasource.h
+++ b/src/grilodatasource.h
@@ -173,14 +173,18 @@ protected:
 
     void timerEvent(QTimerEvent *event);
 
-    guint m_opId;
-    GriloRegistry *m_registry;
+    guint getOpId() const;
+    void setOpId(guint id);
+    GriloRegistry *getGriloRegistry() const;
 
 protected Q_SLOTS:
     virtual void contentChanged(const QString &source, GrlSourceChangeType change_type,
                                 GPtrArray *changed_media);
 
 private:
+    guint m_opId;
+    GriloRegistry *m_registry;
+
     int m_count;
     int m_skip;
     int m_insertIndex;

--- a/src/grilodatasource.h
+++ b/src/grilodatasource.h
@@ -174,20 +174,19 @@ protected:
     void timerEvent(QTimerEvent *event);
 
     guint m_opId;
-
     GriloRegistry *m_registry;
-
-    int m_count;
-    int m_skip;
-    int m_insertIndex;
-    QVariantList m_metadataKeys;
-    QVariantList m_typeFilter;
 
 protected Q_SLOTS:
     virtual void contentChanged(const QString &source, GrlSourceChangeType change_type,
                                 GPtrArray *changed_media);
 
 private:
+    int m_count;
+    int m_skip;
+    int m_insertIndex;
+    QVariantList m_metadataKeys;
+    QVariantList m_typeFilter;
+
     bool m_updateScheduled;
     QBasicTimer m_updateTimer;
     QList<GriloMedia *> m_media;

--- a/src/grilomedia.cpp
+++ b/src/grilomedia.cpp
@@ -125,6 +125,11 @@ QString GriloMedia::artist() const
     return QString::fromUtf8(grl_media_get_artist(m_media));
 }
 
+QString GriloMedia::albumArtist() const
+{
+    return QString::fromUtf8(grl_media_get_album_artist(m_media));
+}
+
 QString GriloMedia::genre() const
 {
     return QString::fromUtf8(grl_media_get_genre(m_media));

--- a/src/grilomedia.cpp
+++ b/src/grilomedia.cpp
@@ -23,27 +23,36 @@
 
 #include <QDebug>
 
-GriloMedia::GriloMedia(GrlMedia *media, QObject *parent)
-    : QObject(parent), m_media(media)
+class GriloMediaPrivate
 {
+public:
+    GrlMedia *m_media;
+};
+
+GriloMedia::GriloMedia(GrlMedia *media, QObject *parent)
+    : QObject(parent)
+    , d(new GriloMediaPrivate)
+{
+    d->m_media = media;
 }
 
 GriloMedia::~GriloMedia()
 {
-    g_object_unref(m_media);
-    m_media = 0;
+    g_object_unref(d->m_media);
+    d->m_media = 0;
+    delete d;
 }
 
 GrlMedia *GriloMedia::media()
 {
-    return m_media;
+    return d->m_media;
 }
 
 void GriloMedia::setMedia(GrlMedia *media)
 {
-    if (m_media != media) {
-        g_object_unref(m_media);
-        m_media = media;
+    if (d->m_media != media) {
+        g_object_unref(d->m_media);
+        d->m_media = media;
     }
 }
 
@@ -65,7 +74,7 @@ QVariant GriloMedia::get(const QString &keyId) const
 
 QVariant GriloMedia::get(const quint32 keyId) const
 {
-    const GValue *gValue = grl_data_get(GRL_DATA(m_media), keyId);
+    const GValue *gValue = grl_data_get(GRL_DATA(d->m_media), keyId);
 
     return convertValue(gValue);
 }
@@ -73,7 +82,7 @@ QVariant GriloMedia::get(const quint32 keyId) const
 QString GriloMedia::serialize()
 {
     QString result;
-    gchar *str = grl_media_serialize_extended(m_media, GRL_MEDIA_SERIALIZE_FULL, NULL);
+    gchar *str = grl_media_serialize_extended(d->m_media, GRL_MEDIA_SERIALIZE_FULL, NULL);
 
     if (str) {
         result = QString::fromUtf8(str);
@@ -85,84 +94,84 @@ QString GriloMedia::serialize()
 
 QString GriloMedia::id() const
 {
-    return QString::fromUtf8(grl_media_get_id(m_media));
+    return QString::fromUtf8(grl_media_get_id(d->m_media));
 }
 
 QString GriloMedia::title() const
 {
-    return QString::fromUtf8(grl_media_get_title(m_media));
+    return QString::fromUtf8(grl_media_get_title(d->m_media));
 }
 
 QUrl GriloMedia::url() const
 {
-    QUrl url = QUrl::fromEncoded(QByteArray(grl_media_get_url(m_media)));
+    QUrl url = QUrl::fromEncoded(QByteArray(grl_media_get_url(d->m_media)));
 
     return url;
 }
 
 int GriloMedia::mediaType() const
 {
-    return static_cast<int>(grl_media_get_media_type(m_media));
+    return static_cast<int>(grl_media_get_media_type(d->m_media));
 }
 
 int GriloMedia::duration() const
 {
-    return grl_media_get_duration(m_media);
+    return grl_media_get_duration(d->m_media);
 }
 
 QString GriloMedia::author() const
 {
-    return QString::fromUtf8(grl_media_get_author(m_media));
+    return QString::fromUtf8(grl_media_get_author(d->m_media));
 }
 
 QString GriloMedia::album() const
 {
-    return QString::fromUtf8(grl_media_get_album(m_media));
+    return QString::fromUtf8(grl_media_get_album(d->m_media));
 }
 
 QString GriloMedia::artist() const
 {
-    return QString::fromUtf8(grl_media_get_artist(m_media));
+    return QString::fromUtf8(grl_media_get_artist(d->m_media));
 }
 
 QString GriloMedia::albumArtist() const
 {
-    return QString::fromUtf8(grl_media_get_album_artist(m_media));
+    return QString::fromUtf8(grl_media_get_album_artist(d->m_media));
 }
 
 QString GriloMedia::genre() const
 {
-    return QString::fromUtf8(grl_media_get_genre(m_media));
+    return QString::fromUtf8(grl_media_get_genre(d->m_media));
 }
 
 QUrl GriloMedia::thumbnail() const
 {
-    return QUrl(grl_media_get_thumbnail(m_media));
+    return QUrl(grl_media_get_thumbnail(d->m_media));
 }
 
 int GriloMedia::year() const
 {
-    return g_date_time_get_year(grl_media_get_creation_date(m_media));
+    return g_date_time_get_year(grl_media_get_creation_date(d->m_media));
  }
 
 int GriloMedia::trackNumber() const
 {
-    return grl_media_get_track_number(m_media);
+    return grl_media_get_track_number(d->m_media);
 }
 
 int GriloMedia::childCount() const
 {
-    return grl_media_get_childcount(m_media);
+    return grl_media_get_childcount(d->m_media);
 }
 
 QString GriloMedia::mimeType() const
 {
-    return QString::fromUtf8(grl_media_get_mime(m_media));
+    return QString::fromUtf8(grl_media_get_mime(d->m_media));
 }
 
 QDateTime GriloMedia::modificationDate() const
 {
-    GDateTime *dateTime = grl_media_get_modification_date(m_media);
+    GDateTime *dateTime = grl_media_get_modification_date(d->m_media);
 
     if (dateTime) {
         return QDateTime::fromTime_t(g_date_time_to_unix(dateTime));
@@ -173,17 +182,17 @@ QDateTime GriloMedia::modificationDate() const
 
 int GriloMedia::height() const
 {
-    return grl_media_get_height(m_media);
+    return grl_media_get_height(d->m_media);
 }
 
 int GriloMedia::orientation() const
 {
-    return grl_media_get_orientation(m_media);
+    return grl_media_get_orientation(d->m_media);
 }
 
 int GriloMedia::width() const
 {
-    return grl_media_get_width(m_media);
+    return grl_media_get_width(d->m_media);
 }
 
 QVariant GriloMedia::convertValue(const GValue *value) const

--- a/src/grilomedia.h
+++ b/src/grilomedia.h
@@ -32,6 +32,8 @@
 #include <QVariant>
 #include <QDateTime>
 
+class GriloMediaPrivate;
+
 class GRILO_QT_EXPORT GriloMedia : public QObject
 {
     Q_OBJECT
@@ -98,7 +100,7 @@ public:
 private:
     QVariant convertValue(const GValue *value) const;
 
-    GrlMedia *m_media;
+    GriloMediaPrivate *d;
 };
 
 #endif /* GRILO_MEDIA_H */

--- a/src/grilomedia.h
+++ b/src/grilomedia.h
@@ -44,6 +44,7 @@ class GRILO_QT_EXPORT GriloMedia : public QObject
     Q_PROPERTY(QString author READ author CONSTANT)
     Q_PROPERTY(QString album READ album CONSTANT)
     Q_PROPERTY(QString artist READ artist CONSTANT)
+    Q_PROPERTY(QString albumArtist READ albumArtist CONSTANT)
     Q_PROPERTY(QString genre READ genre CONSTANT)
     Q_PROPERTY(QUrl thumbnail READ thumbnail CONSTANT)
     Q_PROPERTY(int year READ year CONSTANT)
@@ -54,7 +55,6 @@ class GRILO_QT_EXPORT GriloMedia : public QObject
     Q_PROPERTY(int height READ height CONSTANT)
     Q_PROPERTY(int orientation READ orientation CONSTANT)
     Q_PROPERTY(int width READ width CONSTANT)
-
 
 public:
     enum MediaType {
@@ -76,6 +76,7 @@ public:
     QString author() const;
     QString album() const;
     QString artist() const;
+    QString albumArtist() const;
     QString genre() const;
     QUrl thumbnail() const;
     int year() const;

--- a/src/grilomodel.h
+++ b/src/grilomodel.h
@@ -32,11 +32,11 @@
 
 class GriloMedia;
 class GriloDataSource;
+class GriloModelPrivate;
 
 class GRILO_QT_EXPORT GriloModel : public QAbstractListModel
 {
     Q_OBJECT
-
     Q_PROPERTY(GriloDataSource *source READ source WRITE setSource NOTIFY sourceChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
 
@@ -65,9 +65,7 @@ Q_SIGNALS:
     void countChanged();
 
 private:
-    GriloDataSource *m_source;
-
-    mutable QHash<int, QByteArray> m_roleNames;
+    GriloModelPrivate *d;
 };
 
 #endif /* GRILO_MODEL_H */

--- a/src/grilomultisearch.cpp
+++ b/src/grilomultisearch.cpp
@@ -24,13 +24,22 @@
 
 #include <QDebug>
 
+class GriloMultiSearchPrivate
+{
+public:
+    QStringList m_sources;
+    QString m_text;
+};
+
 GriloMultiSearch::GriloMultiSearch(QObject *parent)
     : GriloDataSource(parent)
+    , d(new GriloMultiSearchPrivate)
 {
 }
 
 GriloMultiSearch::~GriloMultiSearch()
 {
+    delete d;
 }
 
 bool GriloMultiSearch::refresh()
@@ -45,7 +54,7 @@ bool GriloMultiSearch::refresh()
 
     GList *sources = NULL;
 
-    Q_FOREACH (const QString &src, m_sources) {
+    Q_FOREACH (const QString &src, d->m_sources) {
         GrlSource *elem = registry->lookupSource(src);
         if (elem) {
             sources = g_list_append(sources, elem);
@@ -58,7 +67,7 @@ bool GriloMultiSearch::refresh()
     GrlOperationOptions *options = operationOptions(NULL, Search);
 
     setFetching(true);
-    guint opId = grl_multiple_search(sources, m_text.toUtf8().constData(),
+    guint opId = grl_multiple_search(sources, d->m_text.toUtf8().constData(),
                                      keys, options, grilo_source_result_cb, this);
 
     setOpId(opId);
@@ -72,26 +81,26 @@ bool GriloMultiSearch::refresh()
 
 QStringList GriloMultiSearch::sources() const
 {
-    return m_sources;
+    return d->m_sources;
 }
 
 void GriloMultiSearch::setSources(const QStringList &sources)
 {
-    if (m_sources != sources) {
-        m_sources = sources;
+    if (d->m_sources != sources) {
+        d->m_sources = sources;
         Q_EMIT sourcesChanged();
     }
 }
 
 QString GriloMultiSearch::text() const
 {
-    return m_text;
+    return d->m_text;
 }
 
 void GriloMultiSearch::setText(const QString &text)
 {
-    if (m_text != text) {
-        m_text = text;
+    if (d->m_text != text) {
+        d->m_text = text;
         Q_EMIT textChanged();
     }
 }

--- a/src/grilomultisearch.cpp
+++ b/src/grilomultisearch.cpp
@@ -37,7 +37,8 @@ bool GriloMultiSearch::refresh()
 {
     cancelRefresh();
 
-    if (!m_registry) {
+    GriloRegistry *registry = getGriloRegistry();
+    if (!registry) {
         qWarning() << "GriloRegistry not set";
         return false;
     }
@@ -45,7 +46,7 @@ bool GriloMultiSearch::refresh()
     GList *sources = NULL;
 
     Q_FOREACH (const QString &src, m_sources) {
-        GrlSource *elem = m_registry->lookupSource(src);
+        GrlSource *elem = registry->lookupSource(src);
         if (elem) {
             sources = g_list_append(sources, elem);
         } else {
@@ -57,15 +58,16 @@ bool GriloMultiSearch::refresh()
     GrlOperationOptions *options = operationOptions(NULL, Search);
 
     setFetching(true);
-    m_opId = grl_multiple_search(sources, m_text.toUtf8().constData(),
-                                 keys, options, grilo_source_result_cb, this);
+    guint opId = grl_multiple_search(sources, m_text.toUtf8().constData(),
+                                     keys, options, grilo_source_result_cb, this);
 
+    setOpId(opId);
     g_list_free(sources);
 
     g_object_unref(options);
     g_list_free(keys);
 
-    return m_opId != 0;
+    return opId != 0;
 }
 
 QStringList GriloMultiSearch::sources() const

--- a/src/grilomultisearch.h
+++ b/src/grilomultisearch.h
@@ -29,10 +29,11 @@
 
 #include <QStringList>
 
+class GriloMultiSearchPrivate;
+
 class GRILO_QT_EXPORT GriloMultiSearch : public GriloDataSource
 {
     Q_OBJECT
-
     Q_PROPERTY(QStringList sources READ sources WRITE setSources NOTIFY sourcesChanged)
     Q_PROPERTY(QString text READ text WRITE setText NOTIFY textChanged)
 
@@ -53,8 +54,7 @@ Q_SIGNALS:
     void textChanged();
 
 private:
-    QStringList m_sources;
-    QString m_text;
+    GriloMultiSearchPrivate *d;
 };
 
 #endif /* GRILO_MULTI_SEARCH_H */

--- a/src/griloquery.h
+++ b/src/griloquery.h
@@ -27,6 +27,8 @@
 #include <GriloQt>
 #include <GriloDataSource>
 
+class GriloQueryPrivate;
+
 class GRILO_QT_EXPORT GriloQuery : public GriloDataSource
 {
     Q_OBJECT
@@ -66,12 +68,7 @@ private:
                         GPtrArray *changed_media);
     void availableSourcesChanged();
 
-    QString m_source;
-    QString m_query;
-
-    QVariantList m_slowKeys;
-    QVariantList m_supportedKeys;
-    bool m_available;
+    GriloQueryPrivate *d;
 };
 
 #endif /* GRILO_QUERY_H */

--- a/src/griloregistry.cpp
+++ b/src/griloregistry.cpp
@@ -24,48 +24,57 @@
 #include "griloregistry.h"
 #include <QDebug>
 
+class GriloRegistryPrivate
+{
+public:
+    GrlRegistry *m_registry = nullptr;
+    QStringList m_sources;
+    QString m_configurationFile;
+};
 
 GriloRegistry::GriloRegistry(QObject *parent)
     : QObject(parent)
+    , d(new GriloRegistryPrivate)
 {
     grl_init(0, 0);
 
-    m_registry = grl_registry_get_default();
+    d->m_registry = grl_registry_get_default();
 
-    g_signal_connect(m_registry, "source-added", G_CALLBACK(grilo_source_added), this);
-    g_signal_connect(m_registry, "source-removed", G_CALLBACK(grilo_source_removed), this);
+    g_signal_connect(d->m_registry, "source-added", G_CALLBACK(grilo_source_added), this);
+    g_signal_connect(d->m_registry, "source-removed", G_CALLBACK(grilo_source_removed), this);
 
-    GList *sources = grl_registry_get_sources(m_registry, FALSE);
+    GList *sources = grl_registry_get_sources(d->m_registry, FALSE);
     g_list_foreach(sources, connect_source, this);
     g_list_free(sources);
 }
 
 GriloRegistry::~GriloRegistry()
 {
-    Q_FOREACH (const QString &source, m_sources) {
+    Q_FOREACH (const QString &source, d->m_sources) {
         GrlSource *src = lookupSource(source);
         if (src) {
             g_signal_handlers_disconnect_by_data(src, this);
         }
     }
-    g_signal_handlers_disconnect_by_data(m_registry, this);
-    m_registry = 0;
+    g_signal_handlers_disconnect_by_data(d->m_registry, this);
+    d->m_registry = 0;
+    delete d;
 }
 
 QStringList GriloRegistry::availableSources()
 {
-    return m_sources;
+    return d->m_sources;
 }
 
 bool GriloRegistry::loadAll()
 {
     // TODO: error reporting
-    return grl_registry_load_all_plugins(m_registry, TRUE, NULL) == TRUE;
+    return grl_registry_load_all_plugins(d->m_registry, TRUE, NULL) == TRUE;
 }
 
 bool GriloRegistry::loadPluginById(const QString &pluginId)
 {
-    if (!m_registry) {
+    if (!d->m_registry) {
         qCritical() << "No registry object!!!";
         return false;
     }
@@ -73,24 +82,24 @@ bool GriloRegistry::loadPluginById(const QString &pluginId)
     QByteArray id = pluginId.toLocal8Bit();
 
     // Let's try to get the plugin first so we avoid a nasty warning ...
-    if (grl_registry_lookup_plugin(m_registry, id.constData())) {
+    if (grl_registry_lookup_plugin(d->m_registry, id.constData())) {
         return true;
     }
 
     // TODO: error reporting
-    grl_registry_load_all_plugins(m_registry, FALSE, NULL);
-    return grl_registry_activate_plugin_by_id(m_registry, id.constData(), NULL) == TRUE;
+    grl_registry_load_all_plugins(d->m_registry, FALSE, NULL);
+    return grl_registry_activate_plugin_by_id(d->m_registry, id.constData(), NULL) == TRUE;
 }
 
 QString GriloRegistry::configurationFile() const
 {
-    return m_configurationFile;
+    return d->m_configurationFile;
 }
 
 void GriloRegistry::setConfigurationFile(const QString &file)
 {
-    if (m_configurationFile != file) {
-        m_configurationFile = file;
+    if (d->m_configurationFile != file) {
+        d->m_configurationFile = file;
         Q_EMIT configurationFileChanged();
 
         loadConfigurationFile();
@@ -99,9 +108,9 @@ void GriloRegistry::setConfigurationFile(const QString &file)
 
 void GriloRegistry::loadConfigurationFile()
 {
-    if (!m_configurationFile.isEmpty()) {
-        grl_registry_add_config_from_file(m_registry,
-                                          m_configurationFile.toLocal8Bit().constData(),
+    if (!d->m_configurationFile.isEmpty()) {
+        grl_registry_add_config_from_file(d->m_registry,
+                                          d->m_configurationFile.toLocal8Bit().constData(),
                                           NULL);
     }
 }
@@ -109,7 +118,7 @@ void GriloRegistry::loadConfigurationFile()
 void GriloRegistry::connect_source(gpointer data, gpointer user_data)
 {
     GriloRegistry *reg = static_cast<GriloRegistry *>(user_data);
-    grilo_source_added(reg->m_registry, static_cast<GrlSource *>(data), user_data);
+    grilo_source_added(reg->d->m_registry, static_cast<GrlSource *>(data), user_data);
 }
 
 void GriloRegistry::grilo_source_added(GrlRegistry *registry, GrlSource *src,
@@ -121,8 +130,8 @@ void GriloRegistry::grilo_source_added(GrlRegistry *registry, GrlSource *src,
 
     const char *id = grl_source_get_id(src);
 
-    if (reg->m_sources.indexOf(id) == -1) {
-        reg->m_sources << id;
+    if (reg->d->m_sources.indexOf(id) == -1) {
+        reg->d->m_sources << id;
         g_signal_connect(src, "content-changed", G_CALLBACK(grilo_content_changed_cb), reg);
         grl_source_notify_change_start(src, 0);
 
@@ -139,8 +148,8 @@ void GriloRegistry::grilo_source_removed(GrlRegistry *registry, GrlSource *src,
 
     const char *id = grl_source_get_id(src);
 
-    if (int index = reg->m_sources.indexOf(id) != -1) {
-        reg->m_sources.removeAt(index);
+    if (int index = reg->d->m_sources.indexOf(id) != -1) {
+        reg->d->m_sources.removeAt(index);
         g_signal_handlers_disconnect_by_data(src, reg);
         Q_EMIT reg->availableSourcesChanged();
     }
@@ -159,10 +168,10 @@ void GriloRegistry::grilo_content_changed_cb(GrlSource *source, GPtrArray *chang
 
 GrlSource *GriloRegistry::lookupSource(const QString &id)
 {
-    if (!m_registry) {
+    if (!d->m_registry) {
         qCritical() << "No registry object!!!";
         return 0;
     }
 
-    return grl_registry_lookup_source(m_registry, id.toUtf8().constData());
+    return grl_registry_lookup_source(d->m_registry, id.toUtf8().constData());
 }

--- a/src/griloregistry.h
+++ b/src/griloregistry.h
@@ -33,6 +33,8 @@
 #include <QObject>
 #include <QStringList>
 
+class GriloRegistryPrivate;
+
 class GRILO_QT_EXPORT GriloRegistry : public QObject
 {
     Q_OBJECT
@@ -70,10 +72,7 @@ private:
                                          gpointer data);
 
     void loadConfigurationFile();
-
-    GrlRegistry *m_registry;
-    QStringList m_sources;
-    QString m_configurationFile;
+    GriloRegistryPrivate *d;
 };
 
 #endif /* GRILO_REGISTRY_H */

--- a/src/grilosearch.cpp
+++ b/src/grilosearch.cpp
@@ -38,7 +38,8 @@ bool GriloSearch::refresh()
 {
     cancelRefresh();
 
-    if (!m_registry) {
+    GriloRegistry *registry = getGriloRegistry();
+    if (!registry) {
         qWarning() << "GriloRegistry not set";
         return false;
     }
@@ -48,7 +49,7 @@ bool GriloSearch::refresh()
         return false;
     }
 
-    GrlSource *src = m_registry->lookupSource(m_source);
+    GrlSource *src = registry->lookupSource(m_source);
 
     if (!src) {
         qWarning() << "Failed to get source" << m_source;
@@ -58,13 +59,14 @@ bool GriloSearch::refresh()
     GList *keys = keysAsList();
     GrlOperationOptions *options = operationOptions(src, Search);
     setFetching(true);
-    m_opId = grl_source_search(src, m_text.toUtf8().constData(),
-                               keys, options, grilo_source_result_cb, this);
+    guint opId = grl_source_search(src, m_text.toUtf8().constData(),
+                                   keys, options, grilo_source_result_cb, this);
+    setOpId(opId);
 
     g_object_unref(options);
     g_list_free(keys);
 
-    return m_opId != 0;
+    return opId != 0;
 }
 
 QString GriloSearch::source() const
@@ -97,11 +99,13 @@ void GriloSearch::setText(const QString &text)
 
 QVariantList GriloSearch::supportedKeys() const
 {
-    if (m_source.isEmpty() || !m_registry) {
+    GriloRegistry *registry = getGriloRegistry();
+
+    if (m_source.isEmpty() || !registry) {
         return QVariantList();
     }
 
-    GrlSource *src = m_registry->lookupSource(m_source);
+    GrlSource *src = registry->lookupSource(m_source);
     if (src) {
         return listToVariantList(grl_source_supported_keys(src));
     }
@@ -111,11 +115,13 @@ QVariantList GriloSearch::supportedKeys() const
 
 QVariantList GriloSearch::slowKeys() const
 {
-    if (m_source.isEmpty() || !m_registry) {
+    GriloRegistry *registry = getGriloRegistry();
+
+    if (m_source.isEmpty() || !registry) {
         return QVariantList();
     }
 
-    GrlSource *src = m_registry->lookupSource(m_source);
+    GrlSource *src = registry->lookupSource(m_source);
     if (src) {
         return listToVariantList(grl_source_slow_keys(src));
     }
@@ -125,8 +131,10 @@ QVariantList GriloSearch::slowKeys() const
 
 bool GriloSearch::isAvailable() const
 {
-    return m_registry && !m_source.isEmpty() &&
-           m_registry->availableSources().indexOf(m_source) != -1;
+    GriloRegistry *registry = getGriloRegistry();
+
+    return registry && !m_source.isEmpty() &&
+           registry->availableSources().indexOf(m_source) != -1;
 }
 
 void GriloSearch::availableSourcesChanged()
@@ -139,9 +147,9 @@ void GriloSearch::availableSourcesChanged()
         Q_EMIT availabilityChanged();
     }
 
-    if (!m_available && m_opId) {
+    if (!m_available && getOpId()) {
         // A source has disappeared while an operation is already running.
         // Most grilo will crash soon but we will just reset the opId
-        m_opId = 0;
+        setOpId(0);
     }
 }

--- a/src/grilosearch.h
+++ b/src/grilosearch.h
@@ -27,10 +27,11 @@
 #include <GriloQt>
 #include <GriloDataSource>
 
+class GriloSearchPrivate;
+
 class GRILO_QT_EXPORT GriloSearch : public GriloDataSource
 {
     Q_OBJECT
-
     Q_PROPERTY(QString source READ source WRITE setSource NOTIFY sourceChanged)
     Q_PROPERTY(QString text READ text WRITE setText NOTIFY textChanged)
     Q_PROPERTY(QVariantList supportedKeys READ supportedKeys NOTIFY supportedKeysChanged)
@@ -64,12 +65,7 @@ Q_SIGNALS:
 private:
     void availableSourcesChanged();
 
-    QString m_source;
-    QString m_text;
-
-    QVariantList m_slowKeys;
-    QVariantList m_supportedKeys;
-    bool m_available;
+    GriloSearchPrivate *d;
 };
 
 #endif /* GRILO_SEARCH_H */


### PR DESCRIPTION
Multiple commits here:
- Started by noticing qtgrilo may crash the application if the query results have entries with duplicate ids. Added protection for that.
- Had already album artist getter for completeness of the api
- Wanted to add some logs on how long queries take. Adding timer member variable made jolla-mediaplayer crash on ABI change. Annoyed enough to just pimplify the classes now.
- Added a simple optimization related to above for the initial fetch. The enhancement isn't that drastic but it's simple.